### PR TITLE
Fix the link for project's website

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Your README is comprehensive and well-organized. Here are a few enhancements and
 
 ## Overview
 
-**GECTurk WEB** is an open-source web-based tool designed to detect and correct common grammatical and spelling errors in Turkish text. The system not only corrects mistakes but also provides explanations for each correction, helping users learn and understand Turkish grammatical rules better. The platform is accessible both online and offline, making it a flexible tool for native speakers and second language learners alike. You can try out GECTurk WEB at [www.gecturk.net](www.gecturk.net) online or set it up locally using the instructions below.
+**GECTurk WEB** is an open-source web-based tool designed to detect and correct common grammatical and spelling errors in Turkish text. The system not only corrects mistakes but also provides explanations for each correction, helping users learn and understand Turkish grammatical rules better. The platform is accessible both online and offline, making it a flexible tool for native speakers and second language learners alike. You can try out GECTurk WEB at [www.gecturk.net](https://www.gecturk.net/) online or set it up locally using the instructions below.
 
 <p align="center">
 <img src="ui_screenshot.png" width="100%">


### PR DESCRIPTION
Without the schema, it's processed as path - not full URL

This is where that link goes without the fix:

![CleanShot 2024-10-29 at 13 17 07@2x](https://github.com/user-attachments/assets/01215805-2f7b-4559-a638-5db5e08834ff)
